### PR TITLE
refactor: export as ES2015 Module

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,5 +5,5 @@
 module.exports = function(content) {
 	this.cacheable && this.cacheable();
 	this.value = content;
-	return "module.exports = " + JSON.stringify(content);
+	return "export default " + JSON.stringify(content);
 }


### PR DESCRIPTION
Since webpack v2, it's better to use ES modules. Note that this is incompatible with webpack v1, so it should be released as a major version.
