### PR TITLE
fix: escape newline/paragraph separators

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,5 +5,8 @@
 module.exports = function(content) {
 	this.cacheable && this.cacheable();
 	this.value = content;
-	return "export default " + JSON.stringify(content);
+	content = JSON.stringify(content)
+		.replace(/\u2028/g, '\\u2028')
+		.replace(/\u2029/g, '\\u2029');
+	return "export default " + content;
 }


### PR DESCRIPTION
Similar to https://github.com/webpack-contrib/json-loader/pull/18 the `raw-loader` also needs to properly escape the special unicode characters, as otherwise `webpack` get's highly confused when it sees one of them.