### PR TITLE
fix(index): escape invalid characters

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@
   Author Tobias Koppers @sokra
 */
 module.exports = function(source) {
-  this.cacheable && this.cacheable();
   this.value = source;
 
   var json = JSON.stringify(source)

--- a/index.js
+++ b/index.js
@@ -2,13 +2,13 @@
   MIT License http://www.opensource.org/licenses/mit-license.php
   Author Tobias Koppers @sokra
 */
-module.exports = function(content) {
+module.exports = function(rawContent) {
   this.cacheable && this.cacheable();
-  this.value = content;
+  this.value = rawContent;
 
-  var stringified = JSON.stringify(content)
-  .replace(/\u2028/g, '\\u2028')
-  .replace(/\u2029/g, '\\u2029');
+  var stringified = JSON.stringify(rawContent)
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
 
   return "module.exports = " + stringified;
 }

--- a/index.js
+++ b/index.js
@@ -1,9 +1,14 @@
 /*
-	MIT License http://www.opensource.org/licenses/mit-license.php
-	Author Tobias Koppers @sokra
+  MIT License http://www.opensource.org/licenses/mit-license.php
+  Author Tobias Koppers @sokra
 */
 module.exports = function(content) {
-	this.cacheable && this.cacheable();
-	this.value = content;
-	return "module.exports = " + JSON.stringify(content);
+  this.cacheable && this.cacheable();
+  this.value = content;
+
+  var stringified = JSON.stringify(content)
+  .replace(/\u2028/g, '\\u2028')
+  .replace(/\u2029/g, '\\u2029');
+
+  return "module.exports = " + stringified;
 }

--- a/index.js
+++ b/index.js
@@ -2,13 +2,13 @@
   MIT License http://www.opensource.org/licenses/mit-license.php
   Author Tobias Koppers @sokra
 */
-module.exports = function(rawContent) {
+module.exports = function(source) {
   this.cacheable && this.cacheable();
-  this.value = rawContent;
+  this.value = source;
 
-  var stringified = JSON.stringify(rawContent)
+  var json = JSON.stringify(source)
     .replace(/\u2028/g, '\\u2028')
     .replace(/\u2029/g, '\\u2029');
 
-  return "module.exports = " + stringified;
+  return "module.exports = " + json;
 }


### PR DESCRIPTION
### `Notable Changes`

If your raw text has a string with Line separator or Paragraph separator,
they need to be handled outside of JSON.stringify:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#Issue_with_plain_JSON.stringify_for_use_as_JavaScript

The fix here is to replace those characters as directed in the MDN article above.

I also changed the formatting from tabs to 2 spaces :-p

### `Issues`

- Fixes #42