### PR TITLE
Update README.md to be consistent with other loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-<div align="center">
-  <a href="https://github.com/webpack/webpack">
-    <img width="200" height="200" src="https://webpack.js.org/assets/icon-square-big.svg">
-  </a>
-</div>
-
 [![npm][npm]][npm-url]
 [![node][node]][node-url]
 [![deps][deps]][deps-url]
 [![tests][tests]][tests-url]
 [![chat][chat]][chat-url]
+
+<div align="center">
+  <a href="https://github.com/webpack/webpack">
+    <img width="200" height="200" src="https://webpack.js.org/assets/icon-square-big.svg">
+  </a>
+</div>
 
 # raw-loader
 


### PR DESCRIPTION
Other loaders like css-loader and sass-loader follow the proposed change, so this is making it more consistent with those.

Also, the page at https://webpack.js.org/loaders/raw-loader/ shows [![npm][npm]][npm-url][![node][node]][node-url] and so on, even though it shouldn't. Since other pages don't have that issue, seemingly because of the placing of that text in the README.md file, this could fix that issue.

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [x] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->
When I went to https://webpack.js.org/loaders/raw-loader/ I saw that it showed [![npm][npm]][npm-url][![node][node]][node-url] and so on. The other pages don't have that. 

Here is a screenshot it:
![screen shot 2018-05-02 at 7 28 28 pm](https://user-images.githubusercontent.com/38470923/39556659-17acdfbc-4e3f-11e8-825b-f9273adce3a2.png)


### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info