### PR TITLE
refactor: use ES Module export instead of CommonJS

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,5 +12,5 @@ export default function rawLoader(source) {
     .replace(/\u2028/g, '\\u2028')
     .replace(/\u2029/g, '\\u2029');
 
-  return `module.exports = ${json}`;
+  return `export default ${json}`;
 }

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -2,10 +2,10 @@
 
 exports[`loader should works: errors 1`] = `Array []`;
 
-exports[`loader should works: file 1`] = `"module.exports = \\"Где розы — там и тернии —\\\\nТаков закон судьбы.\\\\n\\\\nНиколай Алексеевич Некрасов\\\\n\\\\nWhere the roses are - there are thorns -\\\\nThat is the law of fate.\\\\n\\\\nNikolay Alekseevich Nekrasov\\\\n\\""`;
+exports[`loader should works: file 1`] = `"export default \\"Где розы — там и тернии —\\\\nТаков закон судьбы.\\\\n\\\\nНиколай Алексеевич Некрасов\\\\n\\\\nWhere the roses are - there are thorns -\\\\nThat is the law of fate.\\\\n\\\\nNikolay Alekseevich Nekrasov\\\\n\\""`;
 
-exports[`loader should works: inline 1`] = `"module.exports = \\"Где розы — там и тернии —\\\\nТаков закон судьбы.\\\\n\\\\nНиколай Алексеевич Некрасов\\\\n\\\\nWhere the roses are - there are thorns -\\\\nThat is the law of fate.\\\\n\\\\nNikolay Alekseevich Nekrasov\\\\n\\""`;
+exports[`loader should works: inline 1`] = `"export default \\"Где розы — там и тернии —\\\\nТаков закон судьбы.\\\\n\\\\nНиколай Алексеевич Некрасов\\\\n\\\\nWhere the roses are - there are thorns -\\\\nThat is the law of fate.\\\\n\\\\nNikolay Alekseevich Nekrasov\\\\n\\""`;
 
-exports[`loader should works: separator 1`] = `"module.exports = \\"Word\\\\u2028Word\\\\u2029Word\\\\n\\""`;
+exports[`loader should works: separator 1`] = `"export default \\"Word\\\\u2028Word\\\\u2029Word\\\\n\\""`;
 
 exports[`loader should works: warnings 1`] = `Array []`;


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Since raw-loader now works only with Webpack 4+, we can take advantage of ES Modules and scope hoisting.

### Breaking Changes

If developers use CommonJS style import (`require`), they should probably use `const { default: str } = require('./string.txt')` instead of `import str from './string.txt'`, but I haven’t tested this. Should this be documented?

### Additional Info

N/A.
